### PR TITLE
Add support for registering decoration view classes rather than nibs

### DIFF
--- a/SwiftSpreadsheet/Classes/SpreadsheetLayout.swift
+++ b/SwiftSpreadsheet/Classes/SpreadsheetLayout.swift
@@ -116,37 +116,15 @@ public class SpreadsheetLayout: UICollectionViewLayout {
         self.init()
         self.delegate = delegate
         
-        if let topLeftDeco = topLeftDecorationViewNib {
-            self.decorationViewSet.topLeft = true
-            self.register(topLeftDeco, forDecorationViewOfKind: ViewKindType.DecorationTopLeft.rawValue)
-        } else if let topLeftDeco = topLeftDecorationViewClass {
-            self.decorationViewSet.topLeft = true
-            self.register(topLeftDeco, forDecorationViewOfKind: ViewKindType.DecorationTopLeft.rawValue)
-        }
+        self.decorationViewSet.topLeft = (topLeftDecorationViewNib != nil || topLeftDecorationViewClass != nil)
+        self.decorationViewSet.topRight = (topRightDecorationViewNib != nil || topRightDecorationViewClass != nil)
+        self.decorationViewSet.bottomLeft = (bottomLeftDecorationViewNib != nil || bottomLeftDecorationViewClass != nil)
+        self.decorationViewSet.bottomRight = (bottomRightDecorationViewNib != nil || bottomRightDecorationViewClass != nil)
         
-        if let topRightDeco = topRightDecorationViewNib {
-            self.decorationViewSet.topRight = true
-            self.register(topRightDeco, forDecorationViewOfKind: ViewKindType.DecorationTopRight.rawValue)
-        } else if let topRightDeco = topRightDecorationViewClass {
-            self.decorationViewSet.topRight = true
-            self.register(topRightDeco, forDecorationViewOfKind: ViewKindType.DecorationTopRight.rawValue)
-        }
-        
-        if let bottomLeftDeco = bottomLeftDecorationViewNib {
-            self.decorationViewSet.bottomLeft = true
-            self.register(bottomLeftDeco, forDecorationViewOfKind: ViewKindType.DecorationBottomLeft.rawValue)
-        } else if let bottomLeftDeco = bottomLeftDecorationViewClass {
-            self.decorationViewSet.bottomLeft = true
-            self.register(bottomLeftDeco, forDecorationViewOfKind: ViewKindType.DecorationBottomLeft.rawValue)
-        }
-        
-        if let bottomRightDeco = bottomRightDecorationViewNib {
-            self.decorationViewSet.bottomRight = true
-            self.register(bottomRightDeco, forDecorationViewOfKind: ViewKindType.DecorationBottomRight.rawValue)
-        } else if let bottomRightDeco = bottomRightDecorationViewClass {
-            self.decorationViewSet.bottomRight = true
-            self.register(bottomRightDeco, forDecorationViewOfKind: ViewKindType.DecorationBottomRight.rawValue)
-        }
+        self.register(nib: topLeftDecorationViewNib, orViewClass: topLeftDecorationViewClass, forDecorationViewOfKind: ViewKindType.DecorationTopLeft.rawValue)
+        self.register(nib: topRightDecorationViewNib, orViewClass: topRightDecorationViewClass, forDecorationViewOfKind: ViewKindType.DecorationTopRight.rawValue)
+        self.register(nib: bottomLeftDecorationViewNib, orViewClass: bottomLeftDecorationViewClass, forDecorationViewOfKind: ViewKindType.DecorationBottomLeft.rawValue)
+        self.register(nib: bottomRightDecorationViewNib, orViewClass: bottomRightDecorationViewClass, forDecorationViewOfKind: ViewKindType.DecorationBottomRight.rawValue)
     }
     
     override public func prepare() {
@@ -524,5 +502,14 @@ public class SpreadsheetLayout: UICollectionViewLayout {
         self.bottomLeftGapSpaceLayoutAttributes = nil
         self.bottomRightGapSpaceLayoutAttributes = nil
         self.cacheBuilt = false
+    }
+    
+    private func register(nib: UINib?, orViewClass viewClass: AnyClass?, forDecorationViewOfKind kind: String) {
+        if let nib = nib {
+            self.register(nib, forDecorationViewOfKind: kind)
+        }
+        else if let viewClass = viewClass {
+            self.register(viewClass, forDecorationViewOfKind: kind)
+        }
     }
 }

--- a/SwiftSpreadsheet/Classes/SpreadsheetLayout.swift
+++ b/SwiftSpreadsheet/Classes/SpreadsheetLayout.swift
@@ -104,11 +104,22 @@ public class SpreadsheetLayout: UICollectionViewLayout {
     }
     
     /// Convenience initialiser. Pass delegate and the respective Decoration Views if required.
-    public convenience init(delegate: SpreadsheetLayoutDelegate?, topLeftDecorationViewNib: UINib? = nil, topRightDecorationViewNib: UINib? = nil, bottomLeftDecorationViewNib: UINib? = nil, bottomRightDecorationViewNib: UINib? = nil) {
+    public convenience init(delegate: SpreadsheetLayoutDelegate?,
+                            topLeftDecorationViewNib: UINib? = nil,
+                            topRightDecorationViewNib: UINib? = nil,
+                            bottomLeftDecorationViewNib: UINib? = nil,
+                            bottomRightDecorationViewNib: UINib? = nil,
+                            topLeftDecorationViewClass: AnyClass? = nil,
+                            topRightDecorationViewClass: AnyClass? = nil,
+                            bottomLeftDecorationViewClass: AnyClass? = nil,
+                            bottomRightDecorationViewClass: AnyClass? = nil) {
         self.init()
         self.delegate = delegate
         
         if let topLeftDeco = topLeftDecorationViewNib {
+            self.decorationViewSet.topLeft = true
+            self.register(topLeftDeco, forDecorationViewOfKind: ViewKindType.DecorationTopLeft.rawValue)
+        } else if let topLeftDeco = topLeftDecorationViewClass {
             self.decorationViewSet.topLeft = true
             self.register(topLeftDeco, forDecorationViewOfKind: ViewKindType.DecorationTopLeft.rawValue)
         }
@@ -116,14 +127,23 @@ public class SpreadsheetLayout: UICollectionViewLayout {
         if let topRightDeco = topRightDecorationViewNib {
             self.decorationViewSet.topRight = true
             self.register(topRightDeco, forDecorationViewOfKind: ViewKindType.DecorationTopRight.rawValue)
+        } else if let topRightDeco = topRightDecorationViewClass {
+            self.decorationViewSet.topRight = true
+            self.register(topRightDeco, forDecorationViewOfKind: ViewKindType.DecorationTopRight.rawValue)
         }
         
         if let bottomLeftDeco = bottomLeftDecorationViewNib {
             self.decorationViewSet.bottomLeft = true
             self.register(bottomLeftDeco, forDecorationViewOfKind: ViewKindType.DecorationBottomLeft.rawValue)
+        } else if let bottomLeftDeco = bottomLeftDecorationViewClass {
+            self.decorationViewSet.bottomLeft = true
+            self.register(bottomLeftDeco, forDecorationViewOfKind: ViewKindType.DecorationBottomLeft.rawValue)
         }
         
         if let bottomRightDeco = bottomRightDecorationViewNib {
+            self.decorationViewSet.bottomRight = true
+            self.register(bottomRightDeco, forDecorationViewOfKind: ViewKindType.DecorationBottomRight.rawValue)
+        } else if let bottomRightDeco = bottomRightDecorationViewClass {
             self.decorationViewSet.bottomRight = true
             self.register(bottomRightDeco, forDecorationViewOfKind: ViewKindType.DecorationBottomRight.rawValue)
         }


### PR DESCRIPTION
`UICollectionViewLayout` usually supports registering decoration views as both nibs and classes.
This change is to allow the `SpreadsheetLayout` subclass to also provide that functionality.